### PR TITLE
Add python/lldb/register.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ You can use the [example project][qt6renderer_exmpl] for testsing.
 ## Operating systems tested on
 * Windows
 * Linux  
+* macOS  
 
 ## Architectures tested on
 * x64
+* arm64
 
 ## Manual installation
 
@@ -46,6 +48,15 @@ You can use the [example project][qt6renderer_exmpl] for testsing.
    python gdb.pretty_printers.append(qt6renderer.qt6_lookup)
    set print pretty on
    ```
+
+### LLDB
+
+1. Copy the [qt6renderer lldb](./python/lldb/) folder somewhere at your system
+2. If you don't already have one, create a .lldbinit file in an appropriate place for your OS (on macOS this will be ~/.lldbinit)
+3. Add the following line to your `.lldbinit` (replacing /full/path/to... with the actual full path to register.py):
+```
+command script import "/full/path/to/qt6renderer/lldb/register.py"
+```
 
 ## Requirements
 Pretty printers need Debug information for `Qt`.

--- a/python/lldb/register.py
+++ b/python/lldb/register.py
@@ -1,0 +1,60 @@
+import sys
+import os
+
+# This is derived from the code in:
+# https://github.com/winseros/Qt6RendererIntlj/blob/develop/src/main/java/n/v/k/LLDBRegistrar.java
+
+def __lldb_init_module(debugger, unused):
+    parent = os.path.dirname(os.path.abspath(__file__))
+    debugger.HandleCommand('command script import ' + os.path.join(parent, 'qt6renderer'))
+    registerSummary(debugger, 'QAtomicInt', False);
+    registerSummary(debugger, 'QBasicAtomicInt', False);
+    registerBoth(debugger, 'QBitArray', False);
+    registerBoth(debugger, 'QByteArray', False);
+    registerSummary(debugger, 'QChar', False);
+    registerBoth(debugger, 'QDate', False);
+    registerBoth(debugger, 'QDateTime', False);
+    registerBoth(debugger, 'QDir', False);
+    registerSynth(debugger, 'QEvent', False);
+    registerBoth(debugger, 'QFile', False);
+    registerBoth(debugger, 'QFileInfo', False);
+    registerSummary(debugger, '^QFlags<.*', True);
+    registerBoth(debugger, '^QHash<.*', True);
+    registerSummary(debugger, 'QHostAddress', False);
+    registerBoth(debugger, '^QList<.*', True);
+    registerSynth(debugger, 'QLocale', False);
+    registerSynth(debugger, '^QMap<.*', True);
+    registerBoth(debugger, '^QScopedPointer<.*', True);
+    registerBoth(debugger, '^QSharedPointer<.*', True);
+    registerBoth(debugger, '^QSharedDataPointer<.*', True);
+    registerBoth(debugger, 'QString', False);
+    registerBoth(debugger, 'QTemporaryFile', False);
+    registerBoth(debugger, 'QTemporaryDir', False);
+    registerBoth(debugger, 'QTime', False);
+    registerBoth(debugger, 'QTimeZone', False);
+    registerBoth(debugger, '^QWeakPointer<.*', True);
+    registerBoth(debugger, 'QUrl', False);
+    registerSummary(debugger, 'QUuid', False);
+    registerSynth(debugger, 'QVariant', False);
+    debugger.HandleCommand('type category enable Qt')
+
+
+def registerBoth(debugger, qtType, generic):
+    registerSummary(debugger, qtType, generic)
+    registerSynth(debugger, qtType, generic)
+
+def registerSummary(debugger, qtType, generic):
+    command = 'type summary add -F qt6renderer.qt6_lookup_summary  -e -h'
+    if generic:
+        command += ' -x'
+    command += ' "' + qtType + '"'
+    command += ' --category Qt'
+    debugger.HandleCommand(command)
+
+def registerSynth(debugger, qtType, generic):
+    command = 'type synthetic add -l qt6renderer.qt6_lookup_synthetic'
+    if generic:
+        command += ' -x'
+    command += ' \"' + qtType + '\"'
+    command += ' --category Qt'
+    debugger.HandleCommand(command)


### PR DESCRIPTION
Add python/lldb/register.py file that will register the proper summary and synthetic type handlers when invoked from .lldbinit.
Added instructions to the readme for manual lldb setup.

This allows for simplified setup when using the formatters under Xcode on macOS, and may possibly be useful on Linux as well. 